### PR TITLE
Add support for categories and short names

### DIFF
--- a/pkg/cli-utils.go
+++ b/pkg/cli-utils.go
@@ -39,6 +39,7 @@ type Config struct {
 	Version               string
 	Plural                string
 	Categories            []string
+	ShortNames            []string
 	GetOpenAPIDefinitions GetAPIDefinitions
 }
 
@@ -97,6 +98,7 @@ func NewCustomResourceDefinition(config Config) *extensionsobj.CustomResourceDef
 				Plural:     config.Plural,
 				Kind:       config.Kind,
 				Categories: config.Categories,
+				ShortNames: config.ShortNames,
 			},
 		},
 	}

--- a/pkg/cli-utils.go
+++ b/pkg/cli-utils.go
@@ -18,11 +18,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/ghodss/yaml"
 	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
-	"strings"
 )
 
 // Config stores the user configuration input
@@ -37,6 +38,7 @@ type Config struct {
 	Kind                  string
 	Version               string
 	Plural                string
+	Categories            []string
 	GetOpenAPIDefinitions GetAPIDefinitions
 }
 
@@ -92,8 +94,9 @@ func NewCustomResourceDefinition(config Config) *extensionsobj.CustomResourceDef
 			Version: config.Version,
 			Scope:   extensionsobj.ResourceScope(config.ResourceScope),
 			Names: extensionsobj.CustomResourceDefinitionNames{
-				Plural: config.Plural,
-				Kind:   config.Kind,
+				Plural:     config.Plural,
+				Kind:       config.Kind,
+				Categories: config.Categories,
 			},
 		},
 	}


### PR DESCRIPTION
CRDs allow you to set categories (e.g. `all`) and short names, but you couldn't set these fields with `NewCustomResourceDefinition()`. They're nice conveniences for interacting with the CRs via the command line. This change allows for that.